### PR TITLE
Fix build-format-defs.sh on linux

### DIFF
--- a/build-format-defs.sh
+++ b/build-format-defs.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 for file in ./Cosmic.Formats/defs/*.ksy; do
-    ./kaitai-struct-compiler-0.10/bin/kaitai-struct-compiler.bat -t csharp --outdir ./Cosmic.Formats/gen --dotnet-namespace Cosmic.Formats -I ./Cosmic.Core/Formats/gen $file.FullName
+    ./kaitai-struct-compiler-0.10/bin/kaitai-struct-compiler -t csharp --outdir ./Cosmic.Formats/gen --dotnet-namespace Cosmic.Formats -I ./Cosmic.Core/Formats/gen $file
 done


### PR DESCRIPTION
The script now uses the native shell script for `kaitai-struct-compiler` instead of the bat file, and is now executable